### PR TITLE
chore: bump node to 24.12.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     "vitest": "^4.0.16"
   },
   "volta": {
-    "node": "22.14.0",
+    "node": "24.12.0",
     "pnpm": "10.10.0"
   },
   "packageManager": "pnpm@10.10.0",


### PR DESCRIPTION
## 内容
Node バージョンを 24.12.0 に更新しました。

## 動作確認項目
- [ ] 未実施

## レビュー希望日
12/29 (Mon) までにレビューお願いします！
