### PR TITLE
chore: clean up eslint config

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,7 +80,6 @@
     "tailwindcss": "^3.4.19",
     "typescript": "^5.9.3",
     "typescript-eslint": "^8.50.1",
-    "vite-tsconfig-paths": "^5.1.4",
     "vitest": "^4.0.16"
   },
   "volta": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -177,9 +177,6 @@ importers:
       typescript-eslint:
         specifier: ^8.50.1
         version: 8.50.1(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
-      vite-tsconfig-paths:
-        specifier: ^5.1.4
-        version: 5.1.4(typescript@5.9.3)(vite@7.3.0(@types/node@25.0.3)(jiti@2.6.1)(terser@5.44.1)(yaml@2.8.2))
       vitest:
         specifier: ^4.0.16
         version: 4.0.16(@opentelemetry/api@1.9.0)(@types/node@25.0.3)(@vitest/browser-playwright@4.0.16)(jiti@2.6.1)(jsdom@26.0.0)(msw@2.7.3(@types/node@25.0.3)(typescript@5.9.3))(terser@5.44.1)(yaml@2.8.2)

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -3,14 +3,17 @@ import { fileURLToPath } from 'url';
 
 import { playwright } from '@vitest/browser-playwright';
 import storybookTest from '@storybook/addon-vitest/vitest-plugin';
-import tsconfigPaths from 'vite-tsconfig-paths';
 import { defineConfig, defineProject } from 'vitest/config';
 
 const dirname =
   typeof __dirname !== 'undefined' ? __dirname : path.dirname(fileURLToPath(import.meta.url));
 
 export default defineConfig({
-  plugins: [tsconfigPaths()],
+  resolve: {
+    alias: {
+      '~': path.resolve(dirname, 'src'),
+    },
+  },
   test: {
     environment: 'jsdom',
     coverage: {


### PR DESCRIPTION
## 目的
- ESLint 設定の無駄を削減し、依存を整理

## 変更内容
- eslint-plugin-no-relative-import-paths の設定/依存を削除
- import/order の重複指定を削除

## 動作確認
- pnpm lint
- pnpm test
