### PR TITLE
chore: bump pnpm to 10.26.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -83,9 +83,9 @@
   },
   "volta": {
     "node": "24.12.0",
-    "pnpm": "10.10.0"
+    "pnpm": "10.26.2"
   },
-  "packageManager": "pnpm@10.10.0",
+  "packageManager": "pnpm@10.26.2",
   "pnpm": {
     "onlyBuiltDependencies": [
       "@sentry/cli",


### PR DESCRIPTION
## 目的
- pnpm のバージョンを更新して、DEP0169 警告を回避

## 変更内容
- Volta の pnpm バージョンを 10.26.2 に更新
- packageManager の pnpm バージョンを 10.26.2 に更新

## 動作確認
- pnpm --version
- pnpm install
