### PR TITLE
ci: bump checkout and setup-node to v6

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
       # https://playwright.dev/docs/docker#pull-the-image
       image: mcr.microsoft.com/playwright:v1.57.0-noble
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Use Latest Corepack
         run: |
           echo "Before: corepack version => $(corepack --version || echo 'not installed')"
@@ -25,7 +25,7 @@ jobs:
           pnpm --version
 
       - name: Set Node version
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version-file: './package.json'
           cache: 'pnpm'


### PR DESCRIPTION
## 目的
- Actionsの公式推奨に合わせ、checkout/setup-nodeを最新版へ更新

## 変更点
- actions/checkout@v6
- actions/setup-node@v6

## 確認
- 未実施（CIで確認）