### PR TITLE
fix: avoid theme hydration mismatch

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,6 +31,7 @@
 ## コミット / PR
 - コミット: Conventional Commits 推奨（例: `feat: ...`, `fix: ...`, `refactor: ...`）
 - PR: 目的・変更点、関連 Issue、UI 変更はスクリーンショット、影響範囲と動作確認手順を記載
+- PR: 本文は `.github/pull_request_template.md` を必ず反映して作成・更新する（`gh pr create` / `gh pr edit` の両方を含む）
 - チェック: `pnpm lint && pnpm test && pnpm build` が通ること
 - フック: Husky が `lint-staged`（pre-commit）と `tsc`（pre-push）を実行
 

--- a/src/components/ThemeSwitch/index.tsx
+++ b/src/components/ThemeSwitch/index.tsx
@@ -9,10 +9,7 @@ export const ThemeSwitch = (): JSX.Element | null => {
   const { resolvedTheme, setTheme } = useTheme();
   // next-themes の初期化完了まで描画を抑えて SSR/CSR の差分を避ける。
   const mounted = useSyncExternalStore(
-    (onStoreChange) => {
-      void onStoreChange;
-      return () => undefined;
-    },
+    () => () => undefined,
     () => true,
     () => false,
   );


### PR DESCRIPTION
<!-- I want to review in Japanese. -->
## 内容
- ThemeSwitch の初期描画をクライアントマウント後に限定して hydration 差分を回避
- PR 本文はテンプレート反映必須の運用ルールを追加（AGENTS.md）

## 動作確認項目
- [x] pnpm lint
- [x] pnpm test

## レビュー希望日
12/30 (火) までにレビューお願いします！

<!-- for GitHub Copilot review rule -->
<!--
レビューする際には、以下のprefix(接頭辞)をつけてください
[must]
[imo] (in my opinion)
[nits](nitpick)
[ask]
[fyi]
-->
<!-- for GitHub Copilot review rule-->

<!-- I want to review in Japanese. -->
