### PR TITLE
fix: #295 OG画像APIのEdge Runtime指定を削除

### DIFF
--- a/src/app/api/og/route.tsx
+++ b/src/app/api/og/route.tsx
@@ -4,8 +4,6 @@ import type { NextRequest } from 'next/server';
 
 import { OgImage } from '~/components/OgImage';
 
-export const runtime = 'edge';
-
 export const GET = (request: NextRequest): Response => {
   try {
     const title = request.nextUrl.searchParams.get('title');

--- a/src/tests/api/og.test.tsx
+++ b/src/tests/api/og.test.tsx
@@ -13,15 +13,11 @@ vi.mock('next/og', () => ({
   ImageResponse: ImageResponseMock,
 }));
 
-import { GET, runtime } from '~/app/api/og/route';
+import { GET } from '~/app/api/og/route';
 
 describe('api/og Route Handler', () => {
   beforeEach(() => {
     ImageResponseMock.mockClear();
-  });
-
-  it('Edge Runtimeを使う', () => {
-    expect(runtime).toBe('edge');
   });
 
   it('タイトル付きでImageResponseを返す', () => {


### PR DESCRIPTION
<!-- I want to review in Japanese. -->

## 内容

Issue #295 に対応しました。

- `src/app/api/og/route.tsx` から Edge Runtime 指定を削除し、Node.js Runtime を既定の実行環境に変更
- `src/tests/api/og.test.tsx` から Edge Runtime 固定のテストを削除
- 影響範囲は OG 画像 API の実行環境のみ

Closes #295

## 動作確認項目

- [x] `pnpm test src/tests/api/og.test.tsx`（2件成功）

## レビュー希望日

指定なし

<!-- for GitHub Copilot review rule -->
<!--
レビューする際には、以下のprefix(接頭辞)をつけてください
[must]
[imo] (in my opinion)
[nits](nitpick)
[ask]
[fyi]
-->
<!-- for GitHub Copilot review rule-->

<!-- I want to review in Japanese. -->
