### PR TITLE
chore: Node.jsのバージョン指定を24.xに緩和

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
     "*": "oxfmt --no-error-on-unmatched-pattern"
   },
   "engines": {
-    "node": "24.19.0"
+    "node": "24.x"
   },
   "packageManager": "pnpm@11.19.0"
 }


### PR DESCRIPTION
<!-- I want to review in Japanese. -->

## 内容

Node.js の `engines` バージョン指定を固定値の `24.19.0` から `24.x` に緩和し、Node.js 24 系のパッチ更新を許容します。

## 動作確認項目

- [x] `package.json` の `engines.node` が `24.x` になっていることを差分で確認

<!-- for GitHub Copilot review rule -->
<!--
レビューする際には、以下のprefix(接頭辞)をつけてください
[must]
[imo] (in my opinion)
[nits](nitpick)
[ask]
[fyi]
-->
<!-- for GitHub Copilot review rule-->

<!-- I want to review in Japanese. -->
